### PR TITLE
BadgeNotification is not accessible by Win32 apps

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -174,9 +174,8 @@ Requires macOS 10.5 or higher.
 ### Universal Windows Platform
 
 Requires Windows 10 or higher, and requires that the user agent be a "UWP" app.
-(TODO: Unless this is one of those UWP APIs that can be called from Win32 code?
-Need to investigate.) Note that Google Chrome and Mozilla Firefox do not fall
-into this category, and likely don't have access to the necessary APIs.
+Note that Google Chrome and Mozilla Firefox do not fall into this category, and
+hence don't have access to the necessary APIs.
 
 * The host API is
   [`BadgeNotification`](https://docs.microsoft.com/en-us/uwp/api/windows.ui.notifications.badgenotification),


### PR DESCRIPTION
I tested calling the BadgeNotification API from a Win32 app, and this doesn’t seem to work. Calling the method `Notifications.BadgeUpdateManager.createBadgeUpdaterForApplication()` leads to an exception.

BadgeNotification seems to be one of those APIs requiring a package identity which you could get by packaging the user agent via Desktop App Converter (DAC): https://docs.microsoft.com/en-us/windows/uwp/porting/desktop-to-uwp-run-desktop-app-converter

However, from my understanding, this would still only allow setting a badge notification on the user agent’s tile/taskbar icon.