### PR TITLE
Change integer type from long to [EnforceRange] unsigned long long

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -84,7 +84,7 @@ The model does not allow a badge that is a negative integer, or the integer valu
 The `Badge` interface is a member object on
 [`Window`](https://html.spec.whatwg.org/#the-window-object). It contains two methods:
 
-* `void set(optional long)`: Sets the associated app's badge to the
+* `void set(optional unsigned long)`: Sets the associated app's badge to the
   given data, or just "flag" if the argument is not given.
 * `void clear()`: Sets the associated app's badge to nothing.
 

--- a/explainer.md
+++ b/explainer.md
@@ -84,8 +84,8 @@ The model does not allow a badge that is a negative integer, or the integer valu
 The `Badge` interface is a member object on
 [`Window`](https://html.spec.whatwg.org/#the-window-object). It contains two methods:
 
-* `void set(optional unsigned long)`: Sets the associated app's badge to the
-  given data, or just "flag" if the argument is not given.
+* `void set(optional unsigned long long)`: Sets the associated app's badge to
+  the given data, or just "flag" if the argument is not given.
 * `void clear()`: Sets the associated app's badge to nothing.
 
 These can be called from a foreground page only (calling from a service worker is being

--- a/index.html
+++ b/index.html
@@ -174,9 +174,6 @@
           <li>If <var>contents</var> is 0, set the application's badge to
           <b>nothing</b>.
           </li>
-          <li>Else, if <var>contents</var> is an integer that is less than 0,
-          throw a <a>TypeError</a>.
-          </li>
           <li>Else, set the application's badge to <var>contents</var>.
           </li>
         </ol>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
       <pre class="idl">
         [Exposed=(Window, Worker)]
         interface Badge {
-          static void set(optional long contents);
+          static void set(optional [EnforceRange] long contents);
           static void clear();
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
         </li>
         <li>The special value <b>flag</b>.
         </li>
-        <li>An <code><a data-cite="WEBIDL#idl-unsigned-long">unsigned
+        <li>An <code><a data-cite="WEBIDL#idl-unsigned-long-long">unsigned long
         long</a></code> value, which MUST NOT be 0.
         </li>
       </ul>
@@ -144,7 +144,7 @@
       <pre class="idl">
         [Exposed=(Window, Worker)]
         interface Badge {
-          static void set(optional [EnforceRange] unsigned long contents);
+          static void set(optional [EnforceRange] unsigned long long contents);
           static void clear();
         };
       </pre>

--- a/index.html
+++ b/index.html
@@ -97,8 +97,8 @@
         </li>
         <li>The special value <b>flag</b>.
         </li>
-        <li>A <code><a data-cite="WEBIDL#idl-long">long</a></code> value, which
-        must be positive.
+        <li>An <code><a data-cite="WEBIDL#idl-unsigned-long">unsigned
+        long</a></code> value, which MUST NOT be 0.
         </li>
       </ul>
       <p>
@@ -110,10 +110,6 @@
       <p>
         If the application's badge is <b>nothing</b>, the badge is said to be
         "<dfn>cleared</dfn>". Otherwise, it is said to be "<dfn>set</dfn>".
-      </p>
-      <p>
-        The application's badge MUST NOT contain a negative integer, or the
-        integer value 0.
       </p>
     </section>
     <section>
@@ -148,7 +144,7 @@
       <pre class="idl">
         [Exposed=(Window, Worker)]
         interface Badge {
-          static void set(optional [EnforceRange] long contents);
+          static void set(optional [EnforceRange] unsigned long contents);
           static void clear();
         };
       </pre>


### PR DESCRIPTION
This follows the advice of:
https://w3ctag.github.io/design-principles/#numeric-types

Specific changes are:

- Range errors and type errors converting to a number now raise TypeError
  instead of just setting 0.
- We already didn't allow negative numbers, so it just makes sense to use
  unsigned.
- Integer range is extended to 2^53 (the maximum exact integer representable in
  a JavaScript number). This is ludicrously big (since we'll usually cut off at
  100 anyway), but avoids the "arbitrary" cut-off at 2^32.

Closes #11. Closes #21.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/badging/pull/22.html" title="Last updated on Dec 11, 2018, 11:29 PM GMT (bb873ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/badging/22/3a60431...mgiuca:bb873ff.html" title="Last updated on Dec 11, 2018, 11:29 PM GMT (bb873ff)">Diff</a>