### PR TITLE
Adds an internationalization section

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -271,6 +271,9 @@ However, the only solution to this is a much more limited API which only lets
 you show the count of notifications (or similar). We wanted to give apps the
 full power of showing a native badge.
 
+### Internationalization
+The API allows `set()`ing an `unsigned long long`. When presenting this value, it should be formatted according to the user's locale settings.
+
 ### Security and Privacy Considerations
 The API is set only, so data badged can't be used to track a user. Whether the API is present could possibly be used as a bit of entropy to fingerprint users, but this is the case for all new APIs.
 

--- a/index.html
+++ b/index.html
@@ -136,6 +136,10 @@
         user agent MAY ignore the data, and merely show a marker when the
         status is <a>set</a>.
       </p>
+      <p>
+        When presenting a badge, it SHOULD be formatted according to the user's
+        locale settings.
+      </p>
     </section>
     <section data-dfn-for="Badge">
       <h2>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
           name: "Matt Giuca",
           company: "Google Inc.",
           companyURL: "https://google.com"
+        }, {
+          name: "Jay Harris",
+          company: "Google Inc.",
+          companyURL: "https://google.com"
         }],
         otherLinks: [{
           key: "Implementation status",
@@ -138,7 +142,10 @@
       </p>
       <p>
         When presenting a badge, it SHOULD be formatted according to the user's
-        locale settings.
+        <a data-cite="ltli/#locale">locale</a> settings.
+
+        For example, the badge content '7' should be displayed as '7' in the
+        <a data-cite="ltli/#locale">locale</a> 'en-NZ' but as '٧' in 'ar-EG'.
       </p>
     </section>
     <section data-dfn-for="Badge">


### PR DESCRIPTION
Adds a note on how user agents should format badge values.

> Note: I think we should probably update the spec with this note too, but I'm not sure on the standard procedure?

See #23 for context.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/badging/pull/33.html" title="Last updated on Jun 20, 2019, 3:32 AM UTC (0b2d0a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/badging/33/e1e09e3...0b2d0a1.html" title="Last updated on Jun 20, 2019, 3:32 AM UTC (0b2d0a1)">Diff</a>